### PR TITLE
[ci] Remove unnecessary dependency on qemu.

### DIFF
--- a/.circleci/build_binary.sh
+++ b/.circleci/build_binary.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd "$PROJECT_PATH" || exit 1
+
+# Go won't let us cross-compile if GOBIN is set.
+# shellcheck disable=SC2016
+sed -e 's/GOBIN=$(BINDIR) //' -i Makefile
+
+make build
+
+if test "$GOARCH" == 'amd64'; then
+  cp "$(command -v tiller)" "$DIR"
+else
+  cp "${GOPATH}/bin/linux_${GOARCH}/tiller" "$DIR"
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,15 @@ workflows:
                 - master
 
 shared: &shared
-  machine: true
+  docker:
+    - image: docker:stable-git
   steps:
     - checkout
+    - setup_remote_docker
 
     - run:
         name: Install build dependencies.
-        command: sudo apt update && sudo apt install curl jq
+        command: apk add --no-cache bash curl jq make
 
     - run:
         # Unforunately, there's no easy way to "merge" anchors/references
@@ -40,77 +42,49 @@ shared: &shared
         # this is to dump your # values into a file and source it at build time.
         # @see e.g., https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables
         name: Set up shared environment vars.
-        command: |
-          echo 'export GITHUB_REPO=jessestuart/helm' >> $BASH_ENV
-          echo 'export GO_REPO=k8s.io/helm' >> $BASH_ENV
+        command: .circleci/load_env.sh
 
-          echo 'export GOPATH=/home/circleci/go' >> $BASH_ENV
-          echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
-
-          echo 'export PROJECT_PATH=$GOPATH/src/$GO_REPO' >> $BASH_ENV
-
-          echo 'export VERSION=$(curl -s https://api.github.com/repos/kubernetes/helm/releases/latest | jq -r ".tag_name")' >> $BASH_ENV
-          echo 'export REGISTRY=jessestuart' >> $BASH_ENV
-          echo 'export IMAGE=tiller' >> $BASH_ENV
-          echo 'export IMAGE_ID="${REGISTRY}/${IMAGE}:${VERSION}-${TAG}"' >> $BASH_ENV
-
-          source $BASH_ENV
-
-          sudo rm -rf /usr/local/go
-          sudo mkdir /usr/local/go
-          export CI_USER=$(whoami)
-          sudo chown "${CI_USER}:" /usr/local/go
-
-    - restore_cache:
-        keys:
-          - go-1.10
     - run:
         name: Update Go version.
         command: |
-          if ! (go version | grep 1.10.1); then
-            curl -O https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
-            tar xzf go1.10.1.linux-amd64.tar.gz
-            sudo mv go/ /usr/local
-          fi
-    - save_cache:
-        key: go-1.10
-        paths:
-          - /usr/local/go
+          source "$BASH_ENV"
+          .circleci/install_go.sh
 
     - run:
         name: Install glide.
         command: |
-          curl -sL https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz | tar -xz
+          curl -sL https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz | tar xz
           chmod +x linux-amd64/glide
-          sudo mv linux-amd64/glide /usr/bin
+          mv linux-amd64/glide /usr/bin/glide
 
     - run:
         name: Clone repo.
         command: |
-          mkdir -p $PROJECT_PATH
-          git clone https://github.com/${GITHUB_REPO} --depth=1 \
-            $PROJECT_PATH &>/dev/null
+          source "$BASH_ENV"
+          mkdir -p "$PROJECT_PATH"
+          git clone "https://github.com/${GITHUB_REPO}" --depth=1 "$PROJECT_PATH" &>/dev/null
 
     - restore_cache:
         keys:
-          - glide-{{ checksum "/home/circleci/go/src/k8s.io/helm/glide.yaml" }}-{{ checksum "/home/circleci/go/src/k8s.io/helm/glide.lock" }}
+          - glide-{{ checksum "/root/go/src/k8s.io/helm/glide.yaml" }}-{{ checksum "/root/go/src/k8s.io/helm/glide.lock" }}
           - glide-
+
     - run:
         name: Bootstrap repo dependencies.
         command: |
-          cd $PROJECT_PATH && make bootstrap
+          source "$BASH_ENV"
+          cd "$PROJECT_PATH" && make bootstrap
+
     - save_cache:
-        key: glide-{{ checksum "/home/circleci/go/src/k8s.io/helm/glide.yaml" }}-{{ checksum "/home/circleci/go/src/k8s.io/helm/glide.lock" }}
+        key: glide-{{ checksum "/root/go/src/k8s.io/helm/glide.yaml" }}-{{ checksum "/root/go/src/k8s.io/helm/glide.lock" }}
         paths:
           - /home/circleci/.glide
 
     - run:
         name: Compile architecture-specific tiller binary.
         command: |
-          cd $PROJECT_PATH
-          # Go won't let us cross-compile if GOBIN is set.
-          sed -e 's/GOBIN=$(BINDIR) //' -i Makefile
-          make build
+          source "$BASH_ENV"
+          .circleci/build_binary.sh
 
     - run:
         name: Build and push Docker image.
@@ -122,33 +96,21 @@ jobs:
     <<: *shared
     environment:
       GOARCH: amd64
-      TAG: amd64
       TARGET: amd64
-      QEMU_ARCH: amd64
   build-arm64:
     <<: *shared
     environment:
       GOARCH: arm64
-      QEMU_ARCH: aarch64
-      QEMU_VERSION: v2.11.0
-      TAG: arm64
       TARGET: arm64v8
   build-armhf:
     <<: *shared
     environment:
       GOARCH: arm
-      QEMU_ARCH: arm
-      QEMU_VERSION: v2.11.0
-      TAG: arm
       TARGET: arm32v6
-
-  # =======================================
-  # ---------------------------------------
-  # =======================================
 
   push-manifest:
     docker:
-      - image: docker:18-git
+      - image: docker:stable-git
     environment:
       GITHUB_REPO: kubernetes/helm
       IMAGE: tiller
@@ -157,37 +119,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Determine repo version.
-          command: |
-            apk update && apk add curl jq
-            curl -s https://api.github.com/repos/${GITHUB_REPO}/releases/latest | jq -r ".tag_name" > ~/VERSION
-
-      - run:
-          name: Install manifest-tool.
-          command: |
-            export VERSION=$(cat ~/VERSION)
-            echo "Downloading manifest-tool."
-            wget https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
-            mv manifest-tool-linux-amd64 /usr/bin/manifest-tool
-            chmod +x /usr/bin/manifest-tool
-            manifest-tool --version
-
-      - run:
           name: Push Docker manifest.
           command: |
-            export VERSION=$(cat ~/VERSION)
-            echo "Pushing manifest "$REGISTRY/$IMAGE":latest"
-            echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USER --password-stdin;
-            manifest-tool push from-args \
-              --platforms linux/arm,linux/arm64,linux/amd64 \
-              --template "$REGISTRY/$IMAGE:$VERSION-ARCH" \
-              --target "$REGISTRY/$IMAGE:latest"
-            manifest-tool push from-args \
-              --platforms linux/arm,linux/arm64,linux/amd64 \
-              --template "$REGISTRY/$IMAGE:$VERSION-ARCH" \
-              --target "$REGISTRY/$IMAGE:$VERSION"
-      - run:
-          name: Verify manifest was persisted remotely.
-          command: |
-            export VERSION=$(cat ~/VERSION)
-            manifest-tool inspect "$REGISTRY/$IMAGE:$VERSION"
+            apk add --no-cache bash curl jq
+            .circleci/load_env.sh
+            .circleci/push-manifest.sh

--- a/.circleci/install_go.sh
+++ b/.circleci/install_go.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# echo 'export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"' >> $BASH_ENV
+# source "$BASH_ENV"
+
+rm -rf "$GOROOT" &&
+  mkdir "$GOROOT" &&
+  chown "$(whoami):" "$GOROOT"
+
+# @see https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker
+if ! test -d /lib64; then
+  mkdir /lib64
+fi
+ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+rm -rf /usr/local/go
+curl -sL https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz | tar xz
+mv go/ /usr/local/
+go env && go version

--- a/.circleci/load_env.sh
+++ b/.circleci/load_env.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+echo 'export DIR=`pwd`' >> $BASH_ENV
+echo 'export QEMU_VERSION=v2.12.0' >> $BASH_ENV
+echo 'export GITHUB_REPO=kubernetes/helm' >> $BASH_ENV
+echo 'export GO_REPO=k8s.io/helm' >> $BASH_ENV
+echo 'export VERSION=$(curl -s https://api.github.com/repos/${GITHUB_REPO}/releases | jq -r "sort_by(.tag_name)[-1].tag_name")' >> $BASH_ENV
+
+echo 'export GOPATH=/root/go' >> $BASH_ENV
+echo 'export GOROOT=/usr/local/go' >> $BASH_ENV
+
+echo 'export IMAGE=tiller' >> $BASH_ENV
+echo 'export PROJECT_PATH=$GOPATH/src/$GO_REPO' >> $BASH_ENV
+echo 'export REGISTRY=jessestuart' >> $BASH_ENV
+echo 'export IMAGE_ID="${REGISTRY}/${IMAGE}:${VERSION}-${GOARCH}"' >> $BASH_ENV
+
+echo 'export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"' >> $BASH_ENV
+
+source $BASH_ENV

--- a/.circleci/push-manifest.sh
+++ b/.circleci/push-manifest.sh
@@ -1,22 +1,13 @@
 #!/bin/bash
 
-echo 'Determine repo version.'
-apk update && apk add curl jq
-export VERSION=$(\
-  curl -s https://api.github.com/repos/${GITHUB_REPO}/releases/latest | \
-  jq -r ".tag_name"
-)
-
 echo 'Installing manifest-tool.'
-export VERSION=$(cat ~/VERSION)
-echo "Downloading manifest-tool."
-wget https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64
-mv manifest-tool-linux-amd64 /usr/bin/manifest-tool
-chmod +x /usr/bin/manifest-tool
+wget https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64 && \
+  mv manifest-tool-linux-amd64 /usr/bin/manifest-tool && \
+  chmod +x /usr/bin/manifest-tool
 manifest-tool --version
 
 echo 'Pushing Docker manifest.'
-echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USER --password-stdin;
+docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASS
 
 manifest-tool push from-args \
   --platforms linux/arm,linux/arm64,linux/amd64 \

--- a/.circleci/push-multiarch.sh
+++ b/.circleci/push-multiarch.sh
@@ -1,24 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Copying built binary for $GOARCH."
-if [ $GOARCH == 'amd64' ]; then
-  cp $HOME/go/bin/tiller .
-  touch qemu-amd64-static
-else
-  cp $HOME/go/bin/linux_${GOARCH}/tiller .
-  echo "Loading qemu libs for multi-arch support."
-  curl -sL https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/qemu-${QEMU_ARCH}-static.tar.gz | tar xz
-  docker run --rm --privileged multiarch/qemu-user-static:register
-fi
+export VERSION_TAG="${REGISTRY}/${IMAGE}:${VERSION}-${GOARCH}"
+export LATEST_TAG="${REGISTRY}/${IMAGE}:latest-${GOARCH}"
 
-export VERSION_TAG="${REGISTRY}/${IMAGE}:${VERSION}-${TAG}"
-export LATEST_TAG="${REGISTRY}/${IMAGE}:latest-${TAG}"
-
-docker build -t $VERSION_TAG \
-  --build-arg target=$TARGET \
-  --build-arg arch=$QEMU_ARCH \
-  .
+docker build -t $VERSION_TAG --build-arg target=$TARGET .
 
 echo "Logging in to Docker Hub..."
 echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USER --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,14 @@
 ARG target
-FROM $target/alpine:3.7
-LABEL maintainer="Jesse Stuart <hi@jessestuart.com>"
 
-ARG arch
-ENV ARCH=$arch
-
-COPY qemu-$ARCH-static* /usr/bin/
-
+FROM alpine:3.7 as certs
 RUN apk add --no-cache ca-certificates
 
-ENV HOME /tmp
+FROM $target/alpine:3.7
+LABEL maintainer="Jesse Stuart <hi@jessestuart.com>"
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-COPY tiller /bin/tiller
+COPY tiller /tiller
 
 EXPOSE 44134
 USER nobody
-ENTRYPOINT ["/bin/tiller"]
+ENTRYPOINT ["/tiller"]


### PR DESCRIPTION
### What does this PR do?
- Addresses concerns around the unnecessary inclusion of `qemu` binaries, as raised by @StefanScherer in #1. The updated `Dockerfile` pulls certificates from an `amd64` alpine image, and copies them directly into a multiarch (`arm32v6`/`arm64v8`) image if necessary, eliminating the need for cross-platform execution at build-time. Plus the resulting image is ~1MB smaller without the `qemu-*-static` binary! 🎉
- Miscellaneous cleanup / refactoring.